### PR TITLE
Vertical format implemented (?)

### DIFF
--- a/elements/pl-faded-parsons/pl-faded-parsons-question.mustache
+++ b/elements/pl-faded-parsons/pl-faded-parsons-question.mustache
@@ -20,8 +20,9 @@
 
 
 {{! if vertical, full size boxes }}
-{{! IMPORTANT NOTE: these references to `answers_name` will not dereference since they are not 
-    part of the `vertical` dictionary passed to the rendering method }}
+{{! note: by entering the {#vertical} {/vertical} section, the mustache renderer dereferences 
+          all tags as children of the `vertical` node, which has a duplicate of the 
+          `answers_name` data dereferenced elsewhere }}
 {{#vertical}}
 <div class="pl-faded-parsons row">
   <div id="{{answers_name}}starter-code"     class="col-sm-12 border px-1 sortable-code"></div>

--- a/elements/pl-faded-parsons/pl-faded-parsons-question.mustache
+++ b/elements/pl-faded-parsons/pl-faded-parsons-question.mustache
@@ -8,8 +8,28 @@
 
 <input id="{{answers_name}}code-lines" type="hidden" value="{{{code_lines}}}"/>
 
-{{! the side by side boxes, starter code on left, solution area on right }}
+{{! the boxes for starter code and solution area}}
+
+{{^vertical}}
+{{! if not vertical (horizontal), keep half size boxes }}
 <div class="pl-faded-parsons row">
   <div id="{{answers_name}}starter-code"     class="col-sm-6 border px-1 sortable-code"></div>
   <div id="{{answers_name}}parsons-solution" class="col-sm-6 border sortable-code"></div>
 </div>
+{{/vertical}}
+
+
+{{! if vertical, full size boxes }}
+{{! IMPORTANT NOTE: these references to `answers_name` will not dereference since they are not 
+    part of the `vertical` dictionary passed to the rendering method }}
+{{#vertical}}
+<div class="pl-faded-parsons row">
+  <div id="{{answers_name}}starter-code"     class="col-sm-12 border px-1 sortable-code"></div>
+  
+  {{{pre_text}}}
+  
+  <div id="{{answers_name}}parsons-solution" class="col-sm-12 sortable-code"></div>
+
+  {{{post_text}}}
+</div>
+{{/vertical}}

--- a/elements/pl-faded-parsons/pl-faded-parsons.js
+++ b/elements/pl-faded-parsons/pl-faded-parsons.js
@@ -25,7 +25,8 @@ var ParsonsGlobal = {
       'onSortableUpdate': (event, ui) => {}, // normally would log this event here.
       'trashId': 'starter-code',
       'max_wrong_lines': 1,
-      'trash_label': "Drag from here into the (yellow) solution box below, including indents",
+      'trash_label': "Drag from here into the (yellow) solution box, including indents",
+      'solution_label' : "",
       'syntax_language': 'lang-py' // lang-rb and other choices also acceptable
     });
     ParsonsGlobal.widget.init($('#code-lines').val());

--- a/elements/pl-faded-parsons/pl-faded-parsons.js
+++ b/elements/pl-faded-parsons/pl-faded-parsons.js
@@ -25,6 +25,7 @@ var ParsonsGlobal = {
       'onSortableUpdate': (event, ui) => {}, // normally would log this event here.
       'trashId': 'starter-code',
       'max_wrong_lines': 1,
+      'trash_label': "Drag from here into the (yellow) solution box below, including indents",
       'syntax_language': 'lang-py' // lang-rb and other choices also acceptable
     });
     ParsonsGlobal.widget.init($('#code-lines').val());

--- a/elements/pl-faded-parsons/pl-faded-parsons.md
+++ b/elements/pl-faded-parsons/pl-faded-parsons.md
@@ -55,6 +55,7 @@ file should eventually go in `PrairieLearn:PrairieLearn/docs/elements/pl-faded-p
 
 ![](elements/pl-faded-parsons.png)
 
+Horizontal format:
 ```html
 <pl-question-panel>
   The problem prompt and description of the question goes here.
@@ -66,14 +67,34 @@ file should eventually go in `PrairieLearn:PrairieLearn/docs/elements/pl-faded-p
 </pl-faded-parsons>
 ```
 
+Vetical format:
+```html
+<pl-question-panel>
+  The problem prompt and description of the question goes here.
+</pl-question-panel>
+
+<pl-faded-parsons>
+  <pre-text>
+    Any text to preface the submission box
+  </pre-text>
+  <code-lines>
+    Lines that the student can use to construct their solution
+  </code-lines>
+  <post-text>
+    Any text to succeed the submission box
+  </post-text>
+</pl-faded-parsons>
+```
+
 #### Customizations
 
 Attribute | Type | Default | Description
 --- | --- | --- | ---
-`language`       | string  | "py"       | Language the problem is in, given as the filename extension for files in that language. Currently must be `py` (Python 3).
+`language`       | string  | "py"       | Language the problem is in, given as the filename extension for files in that language. Currently must be `py` (Python 3). If `format="vertical"` is specified, this determines what syntax highlighting to apply to the text in `pre-text` and `post-text`.
 `answers-name`   | string  | "fp"       | Name of answers dict, only matters if >1 Faded Parsons element in same question
 `partial-credit` | boolean | false      | Whether to give partial credit; see below.
 `line-order`     | string  | "alpha"    | How to display the lines of code to the student: `alpha` (alphabetical order), `fixed` (exactly as they appear in `code_lines.py`), or `random`.
+`format`         | string  | "horizontal" | Can be set to "vertical" to opt for the vertical format of presenting the question. In this form, both `pre-text` and `post-text` are entirely optional but the content of `code-lines` is required. If the tag `code-lines` is omitted, the element will search for `code_lines.py` in the `serverFilesQuestion/` sub-directory of the question.
 
 #### Example implementations
 

--- a/elements/pl-faded-parsons/pl-faded-parsons.md
+++ b/elements/pl-faded-parsons/pl-faded-parsons.md
@@ -67,7 +67,7 @@ Horizontal format:
 </pl-faded-parsons>
 ```
 
-Vetical format:
+Vertical format:
 ```html
 <pl-question-panel>
   The problem prompt and description of the question goes here.


### PR DESCRIPTION
I made some changes to allow instructors to specify whether or not to render the boxes in a Faded Parsons Problem stacked vertically or side-by-side (as before).

I will modify `pl-faded-parsons.md` in a future commit to fully describe this behavior. I opened this pull request now to make sure that the approach is sensible.