### PR TITLE
Fixed a couple bugs, perf improvements

### DIFF
--- a/elements/pl-faded-parsons/pl-faded-parsons-question.mustache
+++ b/elements/pl-faded-parsons/pl-faded-parsons-question.mustache
@@ -31,11 +31,11 @@
 <div class="pl-faded-parsons row">
   <div id="{{answers_name}}starter-code"     class="col-sm-12 border px-1 sortable-code"></div>
   
-  {{{pre_text}}}
+  <pl-code {{{language}}}> {{{pre_text}}} </pl-code>
   
   <div id="{{answers_name}}parsons-solution" class="col-sm-12 sortable-code"></div>
 
-  {{{post_text}}}
+  <pl-code {{{language}}}> {{{post_text}}} </pl-code>
 </div>
 {{/vertical}}
 


### PR DESCRIPTION
[Changed lines.](https://github.com/ace-lab/pl-ucb-faded-parsons/blob/62ec32bbcf5cc6272efa4e965cee3cae3eaeda3a/elements/pl-faded-parsons/pl-faded-parsons.py#L86-L118)

The first bug was the compatibility issue. I addressed this by only requiring a code-lines tag/file if there was pre- or post- text.

The second bug was a probable mistake in an f-string, fixed by adding {} around the lang variable name.

The performance improvements were using builtin methods for string whitespace trimming, and new python 3.10 syntax for falsy conditionals.

@nelson-lojo would you check this over? If it's correct I'll merge into main, then into stable.